### PR TITLE
Align dependencies version to master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'django-tastypie==0.11.0',
+        'django-tastypie==0.13.0',
     ]
 )


### PR DESCRIPTION
Fix the above error on running the project in a virtual env with the source code installed from master:

`django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet.`