### PR TITLE
Update default_oauth_apps.json REDIRECT URIs

### DIFF
--- a/fixtures/default_oauth_apps.json
+++ b/fixtures/default_oauth_apps.json
@@ -4,7 +4,7 @@
     "pk": 1001,
     "fields": {
         "skip_authorization": true,
-        "redirect_uris": "http://localhost/geoserver",
+        "redirect_uris": "http://localhost:8080/geoserver\nhttp://localhost/geoserver",
         "name": "GeoServer",
         "authorization_grant_type": "authorization-code",
         "client_type": "confidential",


### PR DESCRIPTION
In order to avoid "paver start" to fail OAuth2 Authentication
add both REDIRECT URIs:

http://localhost:8080/geoserver

and

http://localhost/geoserver