### PR TITLE
cloning with https url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # GeoNode
--e git://github.com/GeoNode/geonode.git@master#egg=geonode
+-e git+https://github.com/GeoNode/geonode.git@master#egg=geonode


### PR DESCRIPTION
While testing, in many platforms the https url is required to avoid errors after the command:
pip install -r requirements.txt --upgrade