### PR TITLE
Align project version with geonode core version

### DIFF
--- a/project_name/__init__.py
+++ b/project_name/__init__.py
@@ -20,7 +20,7 @@
 
 import os
 
-__version__ = (2, 7, 7, 'unstable', 0)
+__version__ = (2, 10, 0, 'rc', 4)
 
 
 default_app_config = "{{project_name}}.apps.AppConfig"


### PR DESCRIPTION
2.7.7 Version in __init.py:master is misleading I would suggest to align it with adressed geonode core version.