### PR TITLE
removed block.super 

### DIFF
--- a/project_name/templates/site_index.html
+++ b/project_name/templates/site_index.html
@@ -4,9 +4,6 @@
 This is where you can override the hero area block. You can simply modify the content below or replace it wholesale to meet your own needs.
 {% endcomment %}
 {% block hero %}
-{% if block.super %}
-{{ block.super }}
-{% else %}
 <div class="jumbotron">
   <div class="container">
       <h1>{{custom_theme.jumbotron_welcome_title|default:_("Welcome")}}</h1>
@@ -17,5 +14,4 @@ This is where you can override the hero area block. You can simply modify the co
       {% endif %}
   </div>
 </div>
-{% endif %}
 {% endblock hero %}


### PR DESCRIPTION
The Current site_index.html does not reflect changes made in the jumbotron because of if statement block super.  See: https://github.com/GeoNode/geonode-project/issues/56

Removing it
- Allows users to make custom changes to jumbotron in site_index.html
- use geonode’s theming app