### PR TITLE
align pavement.py yaml.load with core

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -62,7 +62,7 @@ assert sys.version_info >= (2, 6), \
 
 dev_config = None
 with open("dev_config.yml", 'r') as f:
-    dev_config = yaml.load(f)
+    dev_config = yaml.load(f, Loader=yaml.Loader)
 
 
 def grab(src, dest, name):


### PR DESCRIPTION
fixes 

>pavement.py:65: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

alligns pavement.py with core.
