### PR TITLE
Use project_name for path to initial_data

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -112,7 +112,7 @@ def fixtures(ctx):
 --settings={0}".format(_localsettings()), pty=True)
     ctx.run("python manage.py loaddata /tmp/default_oauth_apps_docker.json \
 --settings={0}".format(_localsettings()), pty=True)
-    ctx.run("python manage.py loaddata /usr/src/{{project_name}}/{{project_name}}/base/fixtures/initial_data.json \
+    ctx.run("python manage.py loaddata /usr/src/{{project_name}}/fixtures/initial_data.json \
 --settings={0}".format(_localsettings()), pty=True)
     ctx.run("python manage.py set_all_layers_alternate \
 --settings={0}".format(_localsettings()), pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -112,7 +112,7 @@ def fixtures(ctx):
 --settings={0}".format(_localsettings()), pty=True)
     ctx.run("python manage.py loaddata /tmp/default_oauth_apps_docker.json \
 --settings={0}".format(_localsettings()), pty=True)
-    ctx.run("python manage.py loaddata /usr/src/geonode/geonode/base/fixtures/initial_data.json \
+    ctx.run("python manage.py loaddata /usr/src/{{project_name}}/{{project_name}}/base/fixtures/initial_data.json \
 --settings={0}".format(_localsettings()), pty=True)
     ctx.run("python manage.py set_all_layers_alternate \
 --settings={0}".format(_localsettings()), pty=True)


### PR DESCRIPTION
Fix for error:

Built Geonode with geonode-project and docker, but site gave `502 Bad Gateway.`

Docker logs django4mygeonode showed:
`CommandError: No fixture named 'initial_data' found.`