### PR TITLE
Fixes #102 LE certificates fail as ACME1 has eol

### DIFF
--- a/docker/letsencrypt/Dockerfile
+++ b/docker/letsencrypt/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 # 1-2. Install system dependencies
 RUN apk add --no-cache certbot py-pip && pip install pyopenssl==16.0.0 # Need to downgrade PyOpenSSL to 16.0.0 to avoid conflicts and solve the cryptography error : https://github.com/plesk/letsencrypt-plesk/issues/117

--- a/docker/letsencrypt/docker-entrypoint.sh
+++ b/docker/letsencrypt/docker-entrypoint.sh
@@ -17,10 +17,10 @@ set +e
 # We run the command
 if [ "$LETSENCRYPT_MODE" == "staging" ]; then
     printf "\nTrying to get STAGING certificate\n"
-    certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --staging
+    certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --staging --server https://acme-v02.api.letsencrypt.org/directory
 elif [ "$LETSENCRYPT_MODE" == "production" ]; then
     printf "\nTrying to get PRODUCTION certificate\n"
-    certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive
+    certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --server https://acme-v02.api.letsencrypt.org/directory
 else
     printf "\nNot trying to get certificate (simulating failure, because LETSENCRYPT_MODE variable was neither staging nor production\n"
     /bin/false
@@ -45,5 +45,5 @@ echo "-----------------------------------------------------"
 echo "FINISHED LETSENCRYPT ENTRYPOINT ---------------------"
 echo "-----------------------------------------------------"
 
-# Run the CMD 
+# Run the CMD
 exec "$@"


### PR DESCRIPTION
Acme1 has reached eol. Hence issuing some certificate will fail. See: GeoNode/geonode#5260

we should update certbot to use ACME2 protocol and endpoint