### PR TITLE
A new volume for B/R in Docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - data-dir-conf
     volumes:
       - geoserver-data-dir:/geoserver_data/data
+      - backup-restore:/backup-restore
     env_file:
       - .env
 
@@ -51,6 +52,7 @@ services:
     volumes:
       - statics:/mnt/volumes/statics
       - geoserver-data-dir:/geoserver_data/data
+      - backup-restore:/backup-restore
     env_file:
       - .env
 
@@ -111,3 +113,5 @@ volumes:
     name: ${COMPOSE_PROJECT_NAME}-dbdata
   dbbackups:
     name: ${COMPOSE_PROJECT_NAME}-dbbackups
+  backup-restore:
+    name: ${COMPOSE_PROJECT_NAME}-backup-restore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - data-dir-conf
     volumes:
       - geoserver-data-dir:/geoserver_data/data
-      - backup-restore:/backup-restore
+      - backup-restore:/backup_restore
     env_file:
       - .env
 
@@ -52,7 +52,7 @@ services:
     volumes:
       - statics:/mnt/volumes/statics
       - geoserver-data-dir:/geoserver_data/data
-      - backup-restore:/backup-restore
+      - backup-restore:/backup_restore
     env_file:
       - .env
 


### PR DESCRIPTION
Creation of a new volume for Geonode's B/R procedure, which is different from `/geoserver_data/data` (to prevent storing old Geoserver backups in the new backup archive)