### PR TITLE
Fixes: 140 Enable LDAP auth

### DIFF
--- a/.env
+++ b/.env
@@ -170,3 +170,14 @@ AVATAR_PROVIDERS='avatar.providers.PrimaryAvatarProvider','avatar.providers.Grav
 EXIF_ENABLED=True
 CREATE_LAYER=True
 FAVORITE_ENABLED=True
+
+# LDAP
+LDAP_ENABLED=False
+LDAP_SERVER_URL=ldap://<the_ldap_server>
+LDAP_BIND_DN=uid=ldapinfo,cn=users,dc=ad,dc=example,dc=org
+LDAP_BIND_PASSWORD=<something_secret>
+LDAP_USER_SEARCH_DN=dc=ad,dc=example,dc=org
+LDAP_USER_SEARCH_FILTERSTR=(&(uid=%(user)s)(objectClass=person))
+LDAP_GROUP_SEARCH_DN=cn=groups,dc=ad,dc=example,dc=org
+LDAP_GROUP_SEARCH_FILTERSTR=(|(cn=abt1)(cn=abt2)(cn=abt3)(cn=abt4)(cn=abt5)(cn=abt6))
+LDAP_GROUP_PROFILE_MEMBER_ATTR=uniqueMember

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN pip install pygdal==$(gdal-config --version).*
 # Install "geonode-contribs" apps
 RUN cd /usr/src; git clone https://github.com/GeoNode/geonode-contribs.git -b master
 # Install logstash and centralized dashboard dependencies
-RUN cd /usr/src/geonode-contribs/geonode-logstash; pip install --upgrade -e .
+RUN cd /usr/src/geonode-contribs/geonode-logstash; pip install --upgrade -e . \
+	cd /usr/src/geonode-contribs/ldap; pip install --upgrade -e
 
 ENTRYPOINT service cron restart && /usr/src/{{project_name}}/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,6 @@ RUN pip install pygdal==$(gdal-config --version).*
 RUN cd /usr/src; git clone https://github.com/GeoNode/geonode-contribs.git -b master
 # Install logstash and centralized dashboard dependencies
 RUN cd /usr/src/geonode-contribs/geonode-logstash; pip install --upgrade -e . \
-	cd /usr/src/geonode-contribs/ldap; pip install --upgrade -e
+	cd /usr/src/geonode-contribs/ldap; pip install --upgrade -e .
 
 ENTRYPOINT service cron restart && /usr/src/{{project_name}}/entrypoint.sh

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -135,11 +135,8 @@ if CENTRALIZED_DASHBOARD_ENABLED and USER_ANALYTICS_ENABLED and 'geonode_logstas
         'schedule': 3600.0,
     }
 
-# LDAP settings
-# For using LDAP authentication uncomment following lines:
-# if 'geonode_ldap' not in INSTALLED_APPS:
-#   INSTALLED_APPS += ('geonode_ldap',)
+if LDAP_ENABLED and 'geonode_ldap' not in INSTALLED_APPS:
+    INSTALLED_APPS += ('geonode_ldap',)
 
-# and add your specific LDAP configuration to this file and in .env 
-# as explained here:
+# Add your specific LDAP configuration after this comment:
 # https://docs.geonode.org/en/master/advanced/contrib/#configuration

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -134,3 +134,13 @@ if CENTRALIZED_DASHBOARD_ENABLED and USER_ANALYTICS_ENABLED and 'geonode_logstas
         'task': 'geonode_logstash.tasks.dispatch_metrics',
         'schedule': 3600.0,
     }
+
+# LDAP settings
+# For using LDAP auth uncomment following lines:
+#if 'geonode_ldap' not in INSTALLED_APPS:
+#  INSTALLED_APPS += ('geonode_ldap',)
+
+# and add your
+# specific LDAP configuration to your settings and .env as explained here:
+# https://docs.geonode.org/en/master/advanced/contrib/#configuration
+# after this line

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -136,11 +136,10 @@ if CENTRALIZED_DASHBOARD_ENABLED and USER_ANALYTICS_ENABLED and 'geonode_logstas
     }
 
 # LDAP settings
-# For using LDAP auth uncomment following lines:
-#if 'geonode_ldap' not in INSTALLED_APPS:
-#  INSTALLED_APPS += ('geonode_ldap',)
+# For using LDAP authentication uncomment following lines:
+# if 'geonode_ldap' not in INSTALLED_APPS:
+#   INSTALLED_APPS += ('geonode_ldap',)
 
-# and add your
-# specific LDAP configuration to your settings and .env as explained here:
+# and add your specific LDAP configuration to this file and in .env 
+# as explained here:
 # https://docs.geonode.org/en/master/advanced/contrib/#configuration
-# after this line


### PR DESCRIPTION
@afabiani 

this adds LDAP auth as discussed at gitter. Where I'm unsure is if I should add the LDAP configuration already commented to settings.py or if it's better to keep it short like:

```
# LDAP settings
# For using LDAP authentication uncomment following lines:
# if 'geonode_ldap' not in INSTALLED_APPS:
#   INSTALLED_APPS += ('geonode_ldap',)

# and add your specific LDAP configuration to this file and in .env 
# as explained here:
# https://docs.geonode.org/en/master/advanced/contrib/#configuration
```

Adding the full configuration might iron out possible questions but spoil the settings file for users that do not use LDAP. What do you think?