### PR TITLE
[Dependencies] Bump celery worker command to v 5.0.0

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -52,7 +52,7 @@ services:
       - db
       - elasticsearch
       - rabbitmq
-    command: celery worker --app={{project_name}}.celeryapp:app -B -l INFO
+    command: celery --app={{project_name}}.celeryapp:app worker -B -l INFO
     volumes:
       - statics:/mnt/volumes/statics
       - geoserver-data-dir:/geoserver_data/data


### PR DESCRIPTION
With version 5 the order of the parameters changes

https://docs.celeryproject.org/en/latest/whatsnew-5.0.html#upgrading-from-celery-4-x