### PR TITLE
[Fixes #7062] Bump to postgresql-client-13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL GeoNode development team
 
 RUN mkdir -p /usr/src/{{project_name}}
 
-# Enable postgresql-client-11.2
+# Enable postgresql-client-13
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN apt-get update && apt-get install -y \
     gcc zip gettext geoip-bin cron \
-    postgresql-client-11 \
+    postgresql-client-13 \
     sqlite3 spatialite-bin libsqlite3-mod-spatialite \
     python3-gdal python3-psycopg2 python3-ldap \
     python3-pip python3-pil python3-lxml python3-pylibmc \


### PR DESCRIPTION
This PR aligns project with core: https://github.com/GeoNode/geonode/pull/7063
It should be backported to 3.2.x, 3.1.x