### PR TITLE
Fix an issue with geonode-mapstore-client broken dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+# The row below allow docker-compose to build images even if 
+# geonode-mapstore-client-3.3.0 is a broken dependency. Can be deleted once geonode-mapstore-client
+# 3.3.0 will be available 
+-e git+https://github.com/GeoNode/geonode-mapstore-client.git@3.3.x#egg=django_geonode_mapstore_client
 -e git+https://github.com/GeoNode/geonode.git@3.3.x#egg=GeoNode
 # GeoNode==3.3.0


### PR DESCRIPTION
geonode-mapstore-client 3.3.0 is not yet released. This fix allow docker-compose to properly build the image. 

It's related to this issue: https://github.com/GeoNode/geonode-project/issues/206