### PR TITLE
Changing virtualenvwrapper.sh fixed path to dynamic

### DIFF
--- a/.env
+++ b/.env
@@ -103,6 +103,12 @@ RESOLVER=127.0.0.11
 # Security
 # #################
 # Admin Settings
+#
+# ADMIN_PASSWORD is used to overwrite the GeoNode admin password **ONLY** the first time
+# GeoNode is run. If you need to overwrite it again, you need to set the env var FORCE_REINIT,
+# otherwise the invoke updateadmin task will be skipped and the current password already stored
+# in DB will be honored.
+
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
 ADMIN_EMAIL=admin@localhost

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ To setup your project using a local python virtual environment, follow these ins
 
     ```bash
     git clone https://github.com/GeoNode/geonode-project.git -b <your_branch>
-    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
+    export VIRTUALENVWRAPPER_PYTHON='/usr/bin/python3'
+    source $(whereis virtualenvwrapper.sh | cut -f 2 -d " ")
     mkvirtualenv --python=/usr/bin/python3 {{ project_name }}
     pip install Django==2.2.12
 
@@ -88,7 +89,8 @@ You need Docker 1.12 or higher, get the latest stable official release for your 
 
     ```bash
     git clone https://github.com/GeoNode/geonode-project.git -b <your_branch>
-    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
+    export VIRTUALENVWRAPPER_PYTHON='/usr/bin/python3'
+    source $(whereis virtualenvwrapper.sh | cut -f 2 -d " ")
     mkvirtualenv --python=/usr/bin/python3 {{ project_name }}
     pip install Django==2.2.15
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,8 @@ else
             echo "monitoringfixture task done"
             /usr/local/bin/invoke initialized > /usr/src/{{project_name}}/invoke.log 2>&1
             echo "initialized"
+            /usr/local/bin/invoke updateadmin > /usr/src/{{project_name}}/invoke.log 2>&1
+            echo "updateadmin task done"
         fi
 
         echo "refresh static data"
@@ -72,8 +74,6 @@ else
         echo "waitforgeoserver task done"
         /usr/local/bin/invoke geoserverfixture > /usr/src/{{project_name}}/invoke.log 2>&1
         echo "geoserverfixture task done"
-        /usr/local/bin/invoke updateadmin > /usr/src/{{project_name}}/invoke.log 2>&1
-        echo "updateadmin task done"
 
         cmd=$UWSGI_CMD
         echo "Executing UWSGI server $cmd for Production"


### PR DESCRIPTION
Hello guys, since seems that location of virtualenvwrapper.sh script is not always "/usr/share/virtualenvwrapper/virtualenvwrapper.sh" ( I guess that different paths depends on if it has been installed with pip or with the specific distribution package manager) , maybe could be safe to use something like 

```
source $(whereis virtualenvwrapper.sh | cut -f 2 -d " ")
```
instead of using a fixed path. 

Indeed, for example, on my ubuntu 18.04, after installing virtualenvwrapper with

```
sudo pip3 install virtualenvwrapper
```

The script will be installed into **/usr/local/bin**. 

Moreover, if you install it with:

```
pip3 install virtualenvwrapper
```

the location will be **~/.local/bin/**, so again different. 

Using a source that load file from the result of **whereis** command should prevent users getting some erros while trying to build new environment.
