### PR TITLE
[Fixes #213] Letsencrypt Certificate Renewal Failure

### DIFF
--- a/docker/letsencrypt/Dockerfile
+++ b/docker/letsencrypt/Dockerfile
@@ -1,8 +1,6 @@
-FROM alpine:3.8
+FROM alpine:3.14
 
-# 1-2. Install system dependencies
-RUN apk add --no-cache certbot py-pip && pip install pyopenssl==16.0.0 # Need to downgrade PyOpenSSL to 16.0.0 to avoid conflicts and solve the cryptography error : https://github.com/plesk/letsencrypt-plesk/issues/117
-
+RUN apk add --no-cache certbot 
 
 # Installing scripts
 ADD docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
Update base Alpine image for letsencrypt. Latest image is pulling a more recent version of _certbot_ from the repositories which is not affected by the issue