### PR TITLE
Removed duplicate ENV vars

### DIFF
--- a/.env
+++ b/.env
@@ -15,8 +15,6 @@ INVOKE_LOG_STDOUT=true
 
 DJANGO_SETTINGS_MODULE={{project_name}}.settings
 GEONODE_INSTANCE_NAME=geonode
-GEONODE_LB_HOST_IP=
-GEONODE_LB_PORT=
 
 # #################
 # backend


### PR DESCRIPTION
```
GEONODE_LB_HOST_IP=
GEONODE_LB_PORT=
```
are defined twice inside the .env file.