### PR TITLE
Removed openjdk-8-jdk from GeoServer Dockerfile

### DIFF
--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -93,7 +93,7 @@ COPY multidump-alt.sh /usr/local/tomcat/tmp
 
 RUN apt-get update \
     && apt-get install -y procps less \
-    && apt-get install -y openjdk-8-jdk python3 python3-pip python3-dev \
+    && apt-get install -y python3 python3-pip python3-dev \
     && chmod +x /usr/local/tomcat/tmp/set_geoserver_auth.sh \
     && chmod +x /usr/local/tomcat/tmp/setup_auth.sh \
     && chmod +x /usr/local/tomcat/tmp/entrypoint.sh \


### PR DESCRIPTION
Seems that openjdk-8-jdk package is no longer available for the distribution used
by tomcat9-jre8 docker image. I tested a build of GeoServer with this PR on development.demo.geonode.org

This fixes issue #226 , and needs to be backported also on 3.2.x and 3.3.x