### PR TITLE
[#242][33x] Collect info into invoke.log file 

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -9,7 +9,7 @@ invoke () {
     then
         /usr/local/bin/invoke $@
     else
-        /usr/local/bin/invoke $@ > /usr/src/{{project_name}}/invoke.log 2>&1
+        /usr/local/bin/invoke $@ >> /usr/src/{{project_name}}/invoke.log 2>&1
     fi
     echo "$@ tasks done"
 }
@@ -78,6 +78,7 @@ else
         invoke prepare
 
         if [ ${FORCE_REINIT} = "true" ]  || [ ${FORCE_REINIT} = "True" ] || [ ! -e "/mnt/volumes/statics/geonode_init.lock" ]; then
+            echo "LOG INIT" > /usr/src/{{project_name}}/invoke.log
             invoke updategeoip
             invoke fixtures
             invoke monitoringfixture


### PR DESCRIPTION
Fix for #242.
Replacing `>` with `>>` when sending output to `invoke.log`.

