### PR TITLE
[Fixes #243] updategeoip should not be called in migrate task

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -187,8 +187,6 @@ def migrations(ctx):
     print("**************************migrations*******************************")
     ctx.run(f"python manage.py migrate --noinput --settings={_localsettings()}", pty=True)
     try:
-        if os.environ.get('MONITORING_ENABLED', False):
-            ctx.run(f"python manage.py updategeoip --settings={_localsettings()}", pty=True)
         ctx.run(f"python manage.py rebuild_index --noinput --settings={_localsettings()}", pty=True)
     except Exception:
         pass


### PR DESCRIPTION
Issue #243
updategeoip is called on its own when reinitializing, so we don't need the task migrate to call it again