### PR TITLE
[#255][33x] Check tests on MONITORING_ENABLED env var

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -275,7 +275,7 @@ def monitoringfixture(ctx):
 @task
 def updategeoip(ctx):
     print("**************************update geoip*******************************")
-    if os.environ.get('MONITORING_ENABLED', False):
+    if ast.literal_eval(os.environ.get('MONITORING_ENABLED', 'False')):
         ctx.run(f"django-admin.py updategeoip --settings={_localsettings()}", pty=True)
 
 


### PR DESCRIPTION
Issue #255
Fix parsing of `MONITORING_ENABLED` env var.