### PR TITLE
added letsencrypt-mode "disabled", so letsencrypt doesn't run loops

### DIFF
--- a/docker/letsencrypt/docker-entrypoint.sh
+++ b/docker/letsencrypt/docker-entrypoint.sh
@@ -21,6 +21,9 @@ if [ "$LETSENCRYPT_MODE" == "staging" ]; then
 elif [ "$LETSENCRYPT_MODE" == "production" ]; then
     printf "\nTrying to get PRODUCTION certificate\n"
     certbot --config-dir "/geonode-certificates/$LETSENCRYPT_MODE" certonly --webroot -w "/geonode-certificates" -d "$HTTPS_HOST" -m "$ADMIN_EMAIL" --agree-tos --non-interactive --server https://acme-v02.api.letsencrypt.org/directory
+elif [ "$LETSENCRYPT_MODE" == "disabled" ]; then
+    printf "\nNot trying to get certificate (because LETSENCRYPT_MODE variable is set to disabled) - and stop container\n"
+    exit 0
 else
     printf "\nNot trying to get certificate (simulating failure, because LETSENCRYPT_MODE variable was neither staging nor production\n"
     /bin/false


### PR DESCRIPTION
Mainly useful if run behind reverse proxy which manages ssl.