### PR TITLE
[Backport to 4.x][Fixes #342] Geoserver Dockerfile, build failed (#343)

### DIFF
--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -91,7 +91,7 @@ RUN apt-get update \
     && chmod +x /usr/local/tomcat/tmp/set_geoserver_auth.sh \
     && chmod +x /usr/local/tomcat/tmp/setup_auth.sh \
     && chmod +x /usr/local/tomcat/tmp/entrypoint.sh \
-    && pip3 install pip==9.0.3 \
+    && pip3 install pip --upgrade \
     && pip3 install -r requirements.txt \
     && chmod +x /usr/local/tomcat/tmp/get_dockerhost_ip.py \
     && chmod +x /usr/local/tomcat/tmp/get_nginxhost_ip.py


### PR DESCRIPTION
(cherry picked from commit 2c389edc15290358f968beb3a7b3ecb69f865319)