### PR TITLE
[Backport to 4.x[Fixes #351][Docker] Wrong healthcheck on Django container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       dockerfile: Dockerfile
     container_name: django4${COMPOSE_PROJECT_NAME}
     healthcheck:
-      test: "curl --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null http://127.0.0.1:8001/"
+      test: "curl --fail --silent --write-out 'HTTP CODE : %{http_code}\n' --output /dev/null http://127.0.0.1:8000/"
       start_period: 60s
       interval: 60s
       timeout: 10s


### PR DESCRIPTION
(cherry picked from commit 0d6fc07fdcd147575b2738b25e525c3071f065a7)