### PR TITLE
[Backport to 4.0.x][Fixes #290] Docker NGINX listen on ports 80/443 (#385)

### DIFF
--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -33,20 +33,14 @@ else
 fi
 
 echo "Sanity checks on http/s ports configuration"
-if [ -z "${HTTP_PORT}" ]; then
-        HTTP_PORT=80
-fi
-if [ -z "${HTTPS_PORT}" ]; then
-        HTTPS_PORT=443
-fi
 if [ -z "${JENKINS_HTTP_PORT}" ]; then
         JENKINS_HTTP_PORT=9080
 fi
 
 echo "Replacing environement variables"
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
-envsubst '\$HTTP_PORT \$HTTPS_PORT \$HTTP_HOST \$HTTPS_HOST \$JENKINS_HTTP_PORT' < /etc/nginx/sites-enabled/geonode.conf.envsubst > /etc/nginx/sites-enabled/geonode.conf
+envsubst '\$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
+envsubst '\$HTTP_HOST \$HTTPS_HOST \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
+envsubst '\$HTTP_HOST \$HTTPS_HOST \$JENKINS_HTTP_PORT' < /etc/nginx/sites-enabled/geonode.conf.envsubst > /etc/nginx/sites-enabled/geonode.conf
 
 echo "Enabling or not https configuration"
 if [ -z "${HTTPS_HOST}" ]; then 

--- a/docker/nginx/nginx.conf.envsubst
+++ b/docker/nginx/nginx.conf.envsubst
@@ -22,7 +22,7 @@ http {
     # even if not used (HTTP_HOST empty), we must keep it as it's used for internal API calls between django and geoserver
     # TODO : do not use unencrypted connection even on LAN, but is it possible to have browser not complaining about unknown authority ?
     server {
-        listen              $HTTP_PORT;
+        listen              80;
         server_name         $HTTP_HOST 127.0.0.1 geonode;
 
         include sites-enabled/*.conf;
@@ -30,8 +30,8 @@ http {
 
     # Default server closes the connection (we can connect only using HTTP_HOST and HTTPS_HOST)
     server {
-        listen          $HTTP_PORT default_server;
-        listen          $HTTPS_PORT;
+        listen          80 default_server;
+        listen          443;
         server_name     _;
         return          444;
     }

--- a/docker/nginx/nginx.https.available.conf.envsubst
+++ b/docker/nginx/nginx.https.available.conf.envsubst
@@ -7,7 +7,7 @@ ssl_session_timeout 10m;
 
 # this is the actual HTTPS host
 server {
-    listen              $HTTPS_PORT ssl;
+    listen              443 ssl;
     server_name         $HTTPS_HOST;
     keepalive_timeout   70;
 


### PR DESCRIPTION
(cherry picked from commit 1e068c87afdef45161cbcf0b5c36544a5ec171b9)