### PR TITLE
Fix geonode 410

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,1 @@
-git+https://github.com/GeoNode/geonode-mapstore-client.git@master#egg=django_geonode_mapstore_client
-git+https://github.com/GeoNode/geonode.git@master#egg=GeoNode
+GeoNode==4.1.0


### PR DESCRIPTION
This is needed to tag 4.1.0 again. It will be reverted to following branch 4.1.x afterward