### PR TITLE
Avoid pip upgrades during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN chmod +x /usr/bin/celery-cmd
 # RUN cd /usr/src/geonode-contribs/geonode-logstash; pip install --upgrade  -e . \
 #     cd /usr/src/geonode-contribs/ldap; pip install --upgrade  -e .
 
-RUN yes w | pip install --src /usr/src -Ur requirements.txt &&\
-    yes w | pip install --upgrade -e .
+RUN yes w | pip install --src /usr/src -r requirements.txt &&\
+    yes w | pip install -e .
 
 # Cleanup apt update lists
 RUN apt-get autoremove --purge &&\


### PR DESCRIPTION
Performing updates in Docker can potentially generate different images on subsequent builds.