### PR TITLE
Update README.md - Fixing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GeoNode template project. Generates a django project with GeoNode support.
   ```bash
     GN_VERSION=master
 
-    django-admin startproject --template=https://github.com/GeoNode/geonode-project/archive/refs/tags/$GN_VERSION.zip -e py,sh,md,rst,json,yml,ini,env,sample,properties -n monitoring-cron -n Dockerfile project_name ~/project_name
+    django-admin startproject --template=https://github.com/GeoNode/geonode-project/archive/refs/heads/$GN_VERSION.zip -e py,sh,md,rst,json,yml,ini,env,sample,properties -n monitoring-cron -n Dockerfile project_name ~/project_name
   ```
 
   ```bash


### PR DESCRIPTION
**Pull Request Description:**

This pull request introduces a minor modification to the README file, specifically in the template ZIP URL for download. The current README suggests using `GN_VERSION` as the master branch for download. However, based on GitHub's documentation regarding source code archives ([GitHub Docs](https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives)), it is recommended to use 'heads' instead of 'tags' when downloading from a branch.

**Changes Made:**
- Updated the template ZIP URL to use 'heads' instead of 'tags' when specifying the branch for download.

**Note:**
- Using 'tags' in the URL previously led to a 404 page, as it is not the correct convention for downloading from a branch.

**References:**
- [GitHub Docs - Downloading Source Code Archives](https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives)

This change ensures that users who want to download from the branch will have the correct URL format and avoid encountering a 404 page.
