### PR TITLE
Increase log levels

### DIFF
--- a/src/project_name/settings.py
+++ b/src/project_name/settings.py
@@ -128,11 +128,11 @@ LOGGING = {
         },
         "celery": {
             "handlers": ["console"],
-            "level": "DEBUG",
+            "level": "ERROR",
         },
         "mapstore2_adapter.plugins.serializers": {
             "handlers": ["console"],
-            "level": "DEBUG",
+            "level": "INFO",
         },
         "geonode_logstash.logstash": {
             "handlers": ["console"],


### PR DESCRIPTION
Increase default log level for celery and mapstore adapter from DEBUG to ERROR and INFO