### PR TITLE
Add configurable project fixture loading mechanism

### DIFF
--- a/src/project_name/settings.py
+++ b/src/project_name/settings.py
@@ -78,5 +78,5 @@ TEMPLATES[0].pop("APP_DIRS", None)
 
 
 PROJECT_FIXTURES = [
-    # Keep any project related fixtures here
+    # List project-related fixture files here, in the order they should be loaded.
 ]

--- a/src/project_name/settings.py
+++ b/src/project_name/settings.py
@@ -76,3 +76,7 @@ loaders = TEMPLATES[0]["OPTIONS"].get("loaders") or [
 TEMPLATES[0]["OPTIONS"]["loaders"] = loaders
 TEMPLATES[0].pop("APP_DIRS", None)
 
+
+PROJECT_FIXTURES = [
+    # Keep any project related fixtures here
+]

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -402,6 +402,20 @@ def fixtures(ctx):
         pty=True,
     )
 
+    # Load Project related fixtures
+    from django.conf import settings
+    project_fixtures = getattr(settings, 'PROJECT_FIXTURES', [])
+
+    for fixture in project_fixtures:
+        if fixture:
+            print(f"Loading project fixture: {fixture}")
+            try:
+                ctx.run(
+                    f"python manage.py loaddata {fixture} --settings={_localsettings()}",
+                    pty=True
+                )
+            except Exception as e:
+                print(f"Warning: Failed to load fixture {fixture}: {str(e)}")
 
 @task
 def collectstatic(ctx):

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -415,7 +415,7 @@ def fixtures(ctx):
                     pty=True
                 )
             except Exception as e:
-                print(f"Warning: Failed to load fixture {fixture}: {str(e)}")
+                print(f"Warning: Failed to load fixture {fixture}: {e}")
 
 @task
 def collectstatic(ctx):


### PR DESCRIPTION
### Overview
This PR introduces a configuration-based approach for loading project-specific fixtures

### Changes
- Add `PROJECT_FIXTURES` setting to define project fixture loading order
- Update `tasks.py` to automatically load project fixtures after core fixtures

### Example Configuration
```python
PROJECT_FIXTURES = [
    # List project-related fixture files here, in the order they should be loaded.
    'fixtures/menus.json',
    'fixtures/locales.json',
]