### PR TITLE
add url-parameter cql-filter to geonode mapstore for filtering feature attributes by url

### DIFF
--- a/src/geonode_project/templates/geonode-mapstore-client/_geonode_config.html
+++ b/src/geonode_project/templates/geonode-mapstore-client/_geonode_config.html
@@ -1,9 +1,59 @@
 {% extends 'geonode-mapstore-client/_geonode_config.html' %}
 {% block override_local_config %}
 <script>
-    window.__GEONODE_CONFIG__.overrideLocalConfig = function(localConfig, _) {
-        // Here the localConfig can be overridden and/or extended
-        return localConfig;
-    };
+    (function() {
+        console.debug('[GeoNode Mapstore] Script gestartet');
+
+        // Read CQL filters from various URL sources
+        function getCqlFilter() {
+            var urlParams = new URLSearchParams(window.location.search);
+            var cqlFilter = urlParams.get('cql_filter') || urlParams.get('CQL_FILTER');
+
+            // Auch aus Hash-Fragment prüfen (für #/?cql_filter=...)
+            if (!cqlFilter && window.location.hash) {
+                var hashQuery = window.location.hash.split('?')[1];
+                if (hashQuery) {
+                    var hashParams = new URLSearchParams(hashQuery);
+                    cqlFilter = hashParams.get('cql_filter') || hashParams.get('CQL_FILTER');
+                }
+            }
+            return cqlFilter;
+        }
+        // Function to add a CQL_FILTER to a URL
+        function addCqlFilterToUrl(url) {
+            if (!url || typeof url !== 'string') return url;
+
+            if(url.includes("geoserver")){
+                // CQL_FILTER zur URL hinzufügen
+                const separator = url.indexOf('?') !== -1 ? '&' : '?';
+                const newUrl = url + separator + 'CQL_FILTER=' + encodeURIComponent(cqlFilter);
+                //console.debug('[GeoNode CQL] CQL_FILTER zu WMS-Request hinzugefügt:', newUrl.substring(0, 150) + '...');
+                return newUrl;
+            }
+            return url;
+        }
+
+        const cqlFilter = getCqlFilter();
+
+        if (cqlFilter) {
+
+            // Intercept Image.src (for tile-based WMS requests)
+            const imageDescriptor = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src');
+            if (imageDescriptor && imageDescriptor.set) {
+                Object.defineProperty(HTMLImageElement.prototype, 'src', {
+                    get: imageDescriptor.get,
+                    set: function(value) {
+                        const modifiedValue = addCqlFilterToUrl(value);
+                        imageDescriptor.set.call(this, modifiedValue);
+                    },
+                    enumerable: true,
+                    configurable: true
+                });
+                console.debug('[GeoNode CQL] Image.src Interception aktiviert');
+            }
+
+            console.debug('[GeoNode CQL] XHR/Fetch/Image Interception aktiviert');
+        }
+    })();
 </script>
 {% endblock %}


### PR DESCRIPTION
if you have web-applications which consume data in form of embbed_urls this is extremely helpful. This changes enables the geonode to filter feature attributes by url. Here are some examples:

* http://localhost/catalogue/#/dataset/1?cql_filter=fid=1
* http://localhost/namespace:layer/embed?cql_filter=fid=1

further documentation how cql-filters work:
* https://docs.geoserver.org/latest/en/user/extensions/kml/features/filters.html
* https://geoserver.org/tutorials/2024/11/11/geospatial-techno.html
* https://docs.geoserver.org/2.27.x/en/user/tutorials/cql/cql_tutorial.html

It's so extremely useful for sub-applications which consumes data of geonode I don't know why this isn't in the main-branch of geonode. In case of any security-/performance-concerns please let us know and I'll reconsider this.

CLOSE #609 