### PR TITLE
[Fixes #615] Replace manage.sh with django-admin in the backup and restore scripts of the 5.0.x branch

### DIFF
--- a/src/project_name/br/backup.sh
+++ b/src/project_name/br/backup.sh
@@ -32,7 +32,7 @@ fi
 
 cd /usr/src/{{project_name}}/ 
 
-./manage.sh backup -i -f -c $PWD/{{project_name}}/br/settings_docker.ini --backup-dir /$BKP_FOLDER_NAME/
+django-admin backup -i -f -c $PWD/{{project_name}}/br/settings_docker.ini --backup-dir /$BKP_FOLDER_NAME/
 
 BKP_FILE_LATEST=$(find /$BKP_FOLDER_NAME/*.zip -type f -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1,NR==1 {print $2}')
 BKP_FILE_NAME=$(echo $BKP_FILE_LATEST | tail -n 1 | grep -oP -m 1 "\/$BKP_FOLDER_NAME\/\K.*" | sed 's|.zip||')

--- a/src/project_name/br/restore.sh
+++ b/src/project_name/br/restore.sh
@@ -71,10 +71,10 @@ if md5sum -c /$BKP_FOLDER_NAME/$NEW_UUID/$BKP_FILE_NAME.md5; then
 
     if md5sum -c /$BKP_FOLDER_NAME/$BKP_FILE_NAME.md5; then
         # The MD5 sum matched
-        ./manage.sh restore -l -n -f --backup-file /$BKP_FOLDER_NAME/$BKP_FILE_NAME.zip --recovery-file /$BKP_FOLDER_NAME/$NEW_UUID/$RECOVERY_FILE_NAME.zip
-        ./manage.sh migrate_baseurl -f --source-address=$SOURCE_URL --target-address=$TARGET_URL
-        ./manage.sh create_tile_layers -f
-        ./manage.sh set_all_datasets_metadata -d -i
+        django-admin restore -l -n -f --backup-file /$BKP_FOLDER_NAME/$BKP_FILE_NAME.zip --recovery-file /$BKP_FOLDER_NAME/$NEW_UUID/$RECOVERY_FILE_NAME.zip
+        django-admin migrate_baseurl -f --source-address=$SOURCE_URL --target-address=$TARGET_URL
+        django-admin create_tile_layers -f
+        django-admin set_all_datasets_metadata -d -i
     else
         # The MD5 sum didn't match
         echo "-----------------------------------------------------"

--- a/src/uwsgi.ini
+++ b/src/uwsgi.ini
@@ -40,7 +40,7 @@ cheaper-busyness-max = 70            ; Above this threshold, spawn new workers
 cheaper-busyness-backlog-alert = 16  ; Spawn emergency workers if more than this many requests are waiting in the queue
 cheaper-busyness-backlog-step = 2    ; How many emergency workers to create if there are too many requests in the queue
 
-# cron = -1 -1 -1 -1 -1 sh -c '/usr/src/{{project_name}}/manage.sh collect_metrics -n -t xml';
+# cron = -1 -1 -1 -1 -1 sh -c 'django-admin collect_metrics -n -t xml';
 # cron = 0 0 -1 -1 -1 sh -c 'find /backup_restore/ -type f -mtime +30 -exec rm -f {} \;'
 # Remove backup files older than 30 days except the most recent 3 files (a backup is composed by 3 files)
 cron = 0 0 -1 -1 -1 sh -c 'find /backup_restore/ -maxdepth 1 -type f -mtime +30 -printf "%T@ %p\n" | sort -n | head -n -3 | awk "{ print $2 }" | xargs -r rm'


### PR DESCRIPTION
This PR was created according to this issue: #615  