### PR TITLE
Fix misleading usage string in create-envfile.py

### DIFF
--- a/create-envfile.py
+++ b/create-envfile.py
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="ENV file builder",
         description="Tool for generate environment file automatically. The information can be passed or via CLI or via JSON file ( --file /path/env.json)",
-        usage="python create-envfile.py localhost -f /path/to/json/file.json",
+        usage="python create-envfile.py -hn localhost -f /path/to/json/file.json",
         allow_abbrev=False
     )
     parser.add_argument(


### PR DESCRIPTION
## Problem

The `argparse` `usage` string in `create-envfile.py` advertises a positional `localhost`:

```
usage="python create-envfile.py localhost -f /path/to/json/file.json"
```

but the parser only accepts the host via `-hn/--hostname` — there is no positional argument. So the documented invocation fails:

```
$ python create-envfile.py localhost
ENV file builder: error: unrecognized arguments: localhost
```

This wrong string is printed by `--help` and on every parse error, which is misleading at the very first setup step a new deployer hits.

## Fix

Align the `usage` string with the actual interface (one line):

```
usage="python create-envfile.py -hn localhost -f /path/to/json/file.json"
```

## Verification

- `python create-envfile.py --help` now shows the corrected usage.
- `python create-envfile.py -hn localhost --noinput` runs and generates `.env` (previously the documented positional form errored).
