### PR TITLE
Bump CodeQL workflow to non-retired action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         config-file: .codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Problem

`.github/workflows/codeql.yml` pins CodeQL Action **v2** (`github/codeql-action/init@v2`, `github/codeql-action/analyze@v2`) and `actions/checkout@v3`.

GitHub **retired CodeQL Action v2** ([changelog, 2025-01-10](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/)). Workflows still on v2 run on an unsupported runtime and may eventually stop working.

## Fix

- `github/codeql-action/init@v2` → `@v3`
- `github/codeql-action/analyze@v2` → `@v3`
- `actions/checkout@v3` → `@v4`

v3 is the current widely-adopted baseline (v4 also exists, but v3 keeps this a minimal, low-risk version bump).

## Verification

- Change is version-string-only; `codeql.yml` still parses as valid YAML.
