### PR TITLE
[Fixes #625] Error flushing memcached in restore

### DIFF
--- a/src/geonode_project/br/restore.sh
+++ b/src/geonode_project/br/restore.sh
@@ -89,7 +89,7 @@ if md5sum -c /$BKP_FOLDER_NAME/$NEW_UUID/$BKP_FILE_NAME.md5; then
         echo "-----------------------------------------------------"
         echo " Cleanup memcached"
         echo "-----------------------------------------------------"
-        echo echo "flush_all" | nc -q 1 memcached 11211
+        echo "flush_all" | nc -q 1 memcached 11211
         echo "-----------------------------------------------------"
         echo "Cache cleanup done"
         echo "-----------------------------------------------------"


### PR DESCRIPTION
## Problem

The post-restore cleanup runs:

```
echo echo "flush_all" | nc -q 1 memcached 11211
```

The doubled `echo` sends the literal string `echo flush_all` to memcached, which isn't a valid command — memcached replies `ERROR` and the cache is never actually flushed. Stale entries can survive a restore until they expire.

## Fix

Drop the duplicated `echo` so the intended `flush_all` command is sent:

```
echo "flush_all" | nc -q 1 memcached 11211
```

## Verification

- `sh -n restore.sh` passes.
- `echo echo "flush_all"` emits `echo flush_all`; `echo "flush_all"` emits `flush_all` — confirming the byte stream sent to memcached.

## Note

This is independent of #618 (which modernizes `create_tile_layers` → `gwc create` on line 76); this touches only the memcached flush on line 92.
