### PR TITLE
[Fixes #625] Fix no-op memcached cache flush in restore.sh

### DIFF
--- a/src/geonode_project/br/restore.sh
+++ b/src/geonode_project/br/restore.sh
@@ -89,7 +89,7 @@ if md5sum -c /$BKP_FOLDER_NAME/$NEW_UUID/$BKP_FILE_NAME.md5; then
         echo "-----------------------------------------------------"
         echo " Cleanup memcached"
         echo "-----------------------------------------------------"
-        echo echo "flush_all" | nc -q 1 memcached 11211
+        echo "flush_all" | nc -q 1 memcached 11211
         echo "-----------------------------------------------------"
         echo "Cache cleanup done"
         echo "-----------------------------------------------------"


### PR DESCRIPTION
#625 

The post-restore cleanup ran 'echo echo "flush_all" | nc ... memcached', which sends the literal string 'echo flush_all' to memcached. That is not a valid command, so memcached replies ERROR and the cache is never flushed. Drop the duplicated echo so the intended 'flush_all' command is sent.