### PR TITLE
Remove unused Docker-SDK port detection in tasks.py

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import re
 import ast
 import json
 import time
@@ -252,21 +251,6 @@ def _docker_host_ip():
             return "127.0.0.1"
 
 
-def _container_exposed_port(component, instname):
-    port = "80"
-    try:
-        client = docker.from_env(version="1.24")
-        for c in client.containers.list(filters={"label": f"org.geonode.component={component}", "status": "running"}):
-            if str(instname) in c.name:
-                exposed_ports = c.attrs["Config"].get("ExposedPorts", {})
-                for key in exposed_ports:
-                    return re.split("/tcp", key)[0]
-    except Exception:
-        import traceback
-        traceback.print_exc()
-    return port
-
-
 def _update_db_connstring():
     connstr = os.getenv("DATABASE_URL", None)
     if not connstr:
@@ -304,10 +288,8 @@ def _geonode_public_host():
 
 def _geonode_public_port():
     gn_pub_port = os.getenv("GEONODE_LB_PORT", "")
-    if not gn_pub_port:
-        gn_pub_port = _container_exposed_port("nginx", os.getenv("GEONODE_INSTANCE_NAME", "geonode"))
-    elif gn_pub_port in ("80", "443"):
-        gn_pub_port = None
+    if not gn_pub_port or gn_pub_port in ("80", "443"):
+        return None
     return gn_pub_port
 
 


### PR DESCRIPTION
Fixes #627.

## Background

`e2c6309` removed the top-level `import docker` from `src/tasks.py` (and moved `_docker_host_ip()` off the Docker SDK), but `_container_exposed_port()` still called `docker.from_env(...)`. With no import, that call raised `NameError`, which the function's `try/except` swallowed — printing a traceback and falling back to `"80"` — on every start where `GEONODE_LB_PORT` is unset.

As discussed in #627 (thanks @mattiagiupponi), the public port is sourced from `GEONODE_LB_PORT`, so the Docker-API detection isn't needed.

## Change

- Remove `_container_exposed_port()` entirely.
- Simplify `_geonode_public_port()` to rely on `GEONODE_LB_PORT`.
- Drop the now-unused `import re` (its only use was inside the removed function).

## Behavior

Equivalent to before. Previously, when `GEONODE_LB_PORT` was unset, `_container_exposed_port()` returned `"80"`, which `update()` then normalized to `None` (via `if ... or pub_port == "80": pub_port = None`). The simplified function returns `None` directly for unset / `"80"` / `"443"`, and the explicit value otherwise — same end result.

## Verification

- `python -m py_compile src/tasks.py` passes.
- No remaining references to `docker.`, `re.`, or `_container_exposed_port` in the module.
